### PR TITLE
Added new functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 This is the Puppet DNS module. It uses the Fog Ruby library to interface with
-your DNS service hosted zone.
+your DNS service hosted zone. The dnsrecord has to be specified by it's fully
+qualified domain name that's taken from the resource title. In case multiple
+records have to be created with the same name, such as one public and one private
+then a record parameter can be used to override the value of the title.
+
+The zone parameter specifies which zone name under which to maintain the record,
+however the zoneid parameter can be used to override the zone name in case there
+are multiple zones with the same name. The ID is the AWS's Hosted Zone ID.
 
 NOTE: Currently only Amazon Web Services (AWS) is supported.
 
@@ -23,3 +30,24 @@ Example:
 			secret => 'my_secret_api_key',
 			require => Dnszone['example.net.'];
 	}
+
+	dnsrecord {
+	 	'my-public-zone':
+	 		ensure => present,
+	 		record  => '123.123.123.123",
+	 		type   => 'A',
+	 		zoneid => 'KKKKKKKKKKKKKKKKKKKKKK',
+	 		id     => 'my_api_key_id',
+			secret => 'my_secret_api_key',
+	}
+
+	dnsrecord {
+	 	'my-private-zone':
+	 		ensure => present,
+	 		record  => '10.10.10.10",
+	 		type   => 'A',
+	 		zoneid => 'HHHHHHHHHHHHHHHHHHHHHHH',
+	 		id     => 'my_api_key_id',
+			secret => 'my_secret_api_key',
+	}
+	

--- a/lib/puppet/provider/dnsrecord/fog.rb
+++ b/lib/puppet/provider/dnsrecord/fog.rb
@@ -45,7 +45,9 @@ Puppet::Type.type(:dnsrecord).provide(:fog,
         # AWS Route 53 doesn't have a CRUD-like interface. In order to "update"
         # it, we'd need to delete a record with the old attributes, and create
         # a record with the new ones.
-        @record.destroy
-        create_record
+        unless @record.nil?
+          @record.destroy
+          create_record
+        end
     end
 end

--- a/lib/puppet/type/dnsrecord.rb
+++ b/lib/puppet/type/dnsrecord.rb
@@ -3,8 +3,13 @@ Puppet::Type.newtype(:dnsrecord) do
     ensurable
 
     newparam(:name) do
-        desc 'Absolute DNS record name.'
+        desc 'Absolute DNS record name or a unique title.'
         isnamevar
+    end
+
+    newparam(:record) do
+        desc 'Absolute DNS record name.'
+        defaultto { @resource[:name] }
 
         validate do |value|
             unless value.match /\.$/
@@ -19,6 +24,17 @@ Puppet::Type.newtype(:dnsrecord) do
         validate do |value|
             unless value.match /\.$/
                 self.fail "(#{value}) absolute DNS names must end with a period."
+            end
+        end
+    end
+
+    newparam(:zoneid) do
+        desc 'Zone ID, will take precidence over zone name'
+        defaultto 'absent'
+
+        validate do |value|
+            unless value.match /.$/
+                self.fail "(#{value}) zone id must be provided."
             end
         end
     end


### PR DESCRIPTION
I added features needed to manage DNS records in multiple zones which have the same name. For example a public zone for aws.example.com which holds public IP addresses and a private zone with the same name (aws.example.com) which holds the private VPC addresses.
