### PR TITLE
DNS Record provider based on the aws-sdk gem

### DIFF
--- a/lib/puppet/feature/aws_sdk.rb
+++ b/lib/puppet/feature/aws_sdk.rb
@@ -1,0 +1,2 @@
+require 'puppet/util/feature'
+Puppet.features.add(:aws_sdk, libs: ['aws-sdk'])

--- a/lib/puppet/feature/fog.rb
+++ b/lib/puppet/feature/fog.rb
@@ -1,0 +1,2 @@
+require 'puppet/util/feature'
+Puppet.features.add(:fog, libs: ['fog'])

--- a/lib/puppet/provider/aws_sdk.rb
+++ b/lib/puppet/provider/aws_sdk.rb
@@ -1,0 +1,72 @@
+require 'puppet/provider'
+class Puppet::Provider::AwsSdk < Puppet::Provider
+    def connection
+        # create a connection to the service
+        @connection ||= ::Aws::Route53::Client.new(credentials: ::Aws::Credentials.new(@resource[:id], @resource[:secret]), region: 'us-east-1')
+    end
+
+    # WARNING: Route53 supports multiple hosted zones of the same name.
+    # This method will return the first match.
+    def zone_by_name name
+        connection.list_hosted_zones_by_name(dns_name: name, max_items: 1).hosted_zones.each do |zone|
+            if zone.name == name
+                return zone.id
+            end
+        end
+        return nil
+    end
+
+    # Create or update the record
+    def upsert_record
+        connection.change_resource_record_sets(
+            hosted_zone_id: @zone,
+            change_batch: {
+                changes: [
+                    {
+                        action: 'UPSERT',
+                        resource_record_set: {
+                            name: @resource[:record],
+                            type: @resource[:type],
+                            ttl: @resource[:ttl],
+                            resource_records: @resource[:value].map { |value| { value: value } }
+                        }
+                    }
+                ]
+            }
+        )
+    end
+
+    def delete_record(record)
+        connection.change_resource_record_sets(
+            hosted_zone_id: @zone,
+            change_batch: {
+                changes: [
+                    {
+                        action: 'DELETE',
+                        resource_record_set: record
+                    }
+                ]
+            }
+        )
+    end
+
+    # Will return the first match
+    def find_record
+        if @zone.nil?
+            if @resource[:zoneid] != 'absent' then
+              @zone = @resource[:zoneid]
+            else
+              @zone = zone_by_name @resource[:zone]
+              if @zone.nil? then
+                  self.fail "No such zone: #{@resource[:zone]}"
+              end
+            end
+        end
+        connection.list_resource_record_sets(hosted_zone_id: @zone, start_record_name: @resource[:record], start_record_type: @resource[:type]).resource_record_sets.each do |record|
+            if record.name == @resource[:record] && record.type == @resource[:type]
+                return record
+            end
+        end
+        return nil
+    end
+end

--- a/lib/puppet/provider/dnsrecord/aws_sdk.rb
+++ b/lib/puppet/provider/dnsrecord/aws_sdk.rb
@@ -1,0 +1,41 @@
+require 'puppet/provider/aws_sdk'
+Puppet::Type.type(:dnsrecord).provide(:aws_sdk,
+                                    :parent => Puppet::Provider::AwsSdk) do
+    confine feature: :aws_sdk
+    desc "DNS Record"
+
+    def exists?
+        @record = find_record
+    end
+
+    def create
+        upsert_record
+    end
+
+    def destroy
+        delete_record(@record)
+        @record = nil
+    end
+
+    def value
+        @record.resource_records.map(&:value)
+    end
+
+    def value= newvalue
+        true
+    end
+
+    def ttl
+        @record.ttl
+    end
+
+    def ttl= newvalue
+        true
+    end
+
+    def flush
+        unless @record.nil?
+          upsert_record
+        end
+    end
+end

--- a/lib/puppet/provider/dnsrecord/fog.rb
+++ b/lib/puppet/provider/dnsrecord/fog.rb
@@ -1,6 +1,7 @@
 require 'puppet/provider/fog'
 Puppet::Type.type(:dnsrecord).provide(:fog,
                                     :parent => Puppet::Provider::Fog) do
+    confine feature: :fog
     desc "DNS Record"
 
     def exists?

--- a/lib/puppet/provider/dnszone/fog.rb
+++ b/lib/puppet/provider/dnszone/fog.rb
@@ -1,6 +1,7 @@
 require 'puppet/provider/fog'
 Puppet::Type.type(:dnszone).provide(:fog,
                                     :parent => Puppet::Provider::Fog) do
+    confine feature: :fog
     desc "DNS Hosted Zone"
 
     def exists?

--- a/lib/puppet/provider/fog.rb
+++ b/lib/puppet/provider/fog.rb
@@ -1,5 +1,4 @@
 require 'puppet/provider'
-require 'fog'
 class Puppet::Provider::Fog < Puppet::Provider
     def connection
         # create a connection to the service

--- a/lib/puppet/type/dnsrecord.rb
+++ b/lib/puppet/type/dnsrecord.rb
@@ -58,7 +58,11 @@ Puppet::Type.newtype(:dnsrecord) do
 
     newproperty(:ttl) do
         desc 'Time To Live (TTL) for query in seconds. Default: 60 seconds'
-        defaultto '60'
+        defaultto 60
+
+        munge do |value|
+            Integer(value)
+        end
     end
 
     newparam(:id) do


### PR DESCRIPTION
The fog gem requires `nokogiri`, which needs a whole bunch of dependencies on each server in order to to compile it (`ruby-dev`, `build-essential`, `libxml-dev`?).

This PR moves the `fog` requirement to a puppet feature (which also allows the `fog` gem to be installed in the same puppet catalog which manages DNS records, if people want to use `fog`), and adds a secondary provider that uses the `aws-sdk` gem which has a much lighter set of dependencies.

Everything should still work for people using `fog`, although I have not tested it as there appear to be no tests for this module.

Also bundles a commit which ensures the `ttl` parameter is an integer, since puppet likes passing integers into providers as strings unless they come from hiera or you do some math on them first.
